### PR TITLE
Add logic for serialized licenses seen with CS 4.3 (no longer gzipped)

### DIFF
--- a/auth_decrypt.py
+++ b/auth_decrypt.py
@@ -117,6 +117,8 @@ def main():
 	elif header == b'\xca\xfe\xc0\xd3':
 		license = decode_license_serial(lic)
 		print_license_serial(license)
+	print('Invalid header!')
+		exit(1)
 
 if __name__ == '__main__':
 	main()

--- a/auth_decrypt.py
+++ b/auth_decrypt.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from Crypto.PublicKey import RSA
 from Crypto.Util.number import bytes_to_long
 from Crypto.Util.number import long_to_bytes
-from struct import unpack
 from hashlib import sha256
 
 def get_args():
@@ -74,13 +73,13 @@ def decode_license_serial(lic):
 	start = index + 1
 	end = start + lic[index]
 
-	end 		= unpack('>I', lic[0:4])[0]
-	watermark 	= unpack('>I', lic[4:8])[0]
+	end 		= int.from_bytes(lic[0:4], byteorder="big")
+	watermark 	= int.from_bytes(lic[4:8], byteorder="big")
 	version     = str(lic[8])
 	key         = sha256(lic[start:end]).hexdigest()
 
 	if end == 29999999:
-		end = 'No End Date'
+		end = 'No end date'
 	else:
 		end = datetime.strptime(end, '%y%m%d').strftime('%b %d %Y')
 
@@ -101,7 +100,6 @@ def print_license_gz(license):
 	print('Issued at:\t{0}'.format(license['issued'].strftime('%b %d %Y %H:%M:%S')))
 
 def print_license_serial(license):
-
 	print ('=== Cobalt Strike auth file details ===')
 	print('License AES key:\t{0}'.format(license['key'][0:16]))
 	print('License HMAC:\t\t{0}'.format(license['key'][16:32]))

--- a/auth_decrypt.py
+++ b/auth_decrypt.py
@@ -6,10 +6,12 @@ from datetime import datetime
 from Crypto.PublicKey import RSA
 from Crypto.Util.number import bytes_to_long
 from Crypto.Util.number import long_to_bytes
+from struct import unpack
+from hashlib import sha256
 
 def get_args():
 	parser = ArgumentParser()
-	
+
 	parser.add_argument(
 		'-p',
 		dest='pubkey',
@@ -37,7 +39,7 @@ def decrypt(pubkey, authfile):
 	plaintext = long_to_bytes(
 		pow(ciphertext, key.e, key.n)
 	)
-	
+
 	unpadded = unpad(plaintext)
 	header = unpadded[:4]
 	data_len = int.from_bytes(unpadded[5:6], byteorder="big")
@@ -49,7 +51,7 @@ def unpad(padded):
 	unpadded = b'\x00'.join(padded.split(b'\x00')[1:])
 	return unpadded
 
-def decode_license(gzip_lic):
+def decode_license_gz(gzip_lic):
 	lic = decompress(gzip_lic).decode().split(',')
 	key 		= lic[0]
 	end 		= datetime.strptime(lic[1], '%y%m%d')
@@ -65,23 +67,58 @@ def decode_license(gzip_lic):
 
 	return license
 
-def print_license(license):
+def decode_license_serial(lic):
+	index = 9
+	for i in range(3):
+		index += lic[index] + 1
+	start = index + 1
+	end = start + lic[index]
+
+	end 		= unpack('>I', lic[0:4])[0]
+	watermark 	= unpack('>I', lic[4:8])[0]
+	version     = str(lic[8])
+	key         = sha256(lic[start:end]).hexdigest()
+
+	if end == 29999999:
+		end = 'No End Date'
+	else:
+		end = datetime.strptime(end, '%y%m%d').strftime('%b %d %Y')
+
+	license = {
+		'key'		: key,
+		'end'		: end,
+		'watermark'	: watermark,
+		'version'	: version
+	}
+
+	return license
+
+def print_license_gz(license):
 	print ('=== Cobalt Strike auth file details ===')
 	print('License key:\t{0}'.format(license['key']))
 	print('End date:\t{0}'.format(license['end'].strftime('%b %d %Y')))
 	print('Watermark:\t{0}'.format(license['watermark']))
 	print('Issued at:\t{0}'.format(license['issued'].strftime('%b %d %Y %H:%M:%S')))
 
+def print_license_serial(license):
+
+	print ('=== Cobalt Strike auth file details ===')
+	print('License AES key:\t{0}'.format(license['key'][0:16]))
+	print('License HMAC:\t\t{0}'.format(license['key'][16:32]))
+	print('End date:\t\t{0}'.format(license['end']))
+	print('Watermark:\t\t{0}'.format(license['watermark']))
+	print('Version Number:\t\t{0}.{1}'.format(license['version'][0], license['version'][1:]))
+
 def main():
 	args = get_args()
-	header, gzip_lic = decrypt(args.pubkey, args.authfile)
+	header, lic = decrypt(args.pubkey, args.authfile)
 
-	if header != b'\xca\xfe\xc0\xbb':
-		print('Invalid header!')
-		exit(1)
-
-	license = decode_license(gzip_lic)
-	print_license(license)
+	if header == b'\xca\xfe\xc0\xbb':
+		license = decode_license_gz(lic)
+		print_license_gz(license)
+	elif header == b'\xca\xfe\xc0\xd3':
+		license = decode_license_serial(lic)
+		print_license_serial(license)
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
Howdy, my code is bad but the logic is there. Change the python as you wish, but please implement the new logic as your tool is the first one that comes up on google! There does not appear to be an issued date anymore. I have included the decompiled `Authorization.class` below for CS 4.3:

``` Java
package common;

import java.io.File;

public class Authorization {
    protected String error = null;
    protected boolean valid = false;
    protected String validto = "";
    protected int watermark = 0;

    public Authorization() {
        String canonicalize = CommonUtils.canonicalize("cobaltstrike.auth");
        if (!new File(canonicalize).exists()) {
            try {
                File file = new File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
                if (file.getName().toLowerCase().endsWith(".jar")) {
                    file = file.getParentFile();
                }
                canonicalize = new File(file, "cobaltstrike.auth").getAbsolutePath();
            } catch (Exception e) {
                MudgeSanity.logException("trouble locating auth file", e, false);
            }
        }
        byte[] readFile = CommonUtils.readFile(canonicalize);
        if (readFile.length == 0) {
            this.error = "Could not read " + canonicalize;
            return;
        }
        AuthCrypto authCrypto = new AuthCrypto();
        byte[] decrypt = authCrypto.decrypt(readFile);
        if (decrypt.length == 0) {
            this.error = authCrypto.error();
            return;
        }
        try {
            DataParser dataParser = new DataParser(decrypt);
            dataParser.big();
            int readInt = dataParser.readInt();
            this.watermark = dataParser.readInt();
            if (dataParser.readByte() < 43) {
                this.error = "Authorization file is not for Cobalt Strike 4.3+";
                return;
            }
            dataParser.readBytes(dataParser.readByte());
            dataParser.readBytes(dataParser.readByte());
            dataParser.readBytes(dataParser.readByte());
            byte[] readBytes = dataParser.readBytes(dataParser.readByte());
            if (29999999 == readInt) {
                this.validto = "forever";
                MudgeSanity.systemDetail("valid to", "perpetual");
            } else {
                this.validto = "20" + readInt;
                MudgeSanity.systemDetail("valid to", CommonUtils.formatDateAny("MMMMM d, YYYY", getExpirationDate()));
            }
            this.valid = true;
            MudgeSanity.systemDetail("id", this.watermark + "");
            SleevedResource.Setup(readBytes);
        } catch (Exception e2) {
            MudgeSanity.logException("auth file parsing", e2, false);
        }
    }

    public String getError() {
        return this.error;
    }

    public long getExpirationDate() {
        return CommonUtils.parseDate(this.validto, "yyyyMMdd");
    }

    public String getWatermark() {
        return this.watermark + "";
    }

    public boolean isAlmostExpired() {
        return System.currentTimeMillis() + CommonUtils.days(30) > getExpirationDate();
    }

    public boolean isExpired() {
        return System.currentTimeMillis() > getExpirationDate() + CommonUtils.days(1);
    }

    public boolean isPerpetual() {
        return "forever".equals(this.validto);
    }

    public boolean isValid() {
        return this.valid;
    }

    public String whenExpires() {
        long expirationDate = ((getExpirationDate() + CommonUtils.days(1)) - System.currentTimeMillis()) / CommonUtils.days(1);
        return expirationDate == 1 ? "1 day (" + CommonUtils.formatDateAny("MMMMM d, YYYY", getExpirationDate()) + ")" : expirationDate <= 0 ? "TODAY (" + CommonUtils.formatDateAny("MMMMM d, YYYY", getExpirationDate()) + ")" : expirationDate + " days (" + CommonUtils.formatDateAny("MMMMM d, YYYY", getExpirationDate()) + ")";
    }
}
```